### PR TITLE
added public keyword to members in example struct class in resource management explanation

### DIFF
--- a/app/manual/04_resources.md
+++ b/app/manual/04_resources.md
@@ -240,9 +240,10 @@ Up to this point we only worked with resources. Resources are classes. But somet
  // RGB Color
 class NAPAPI Color
 {
-	float r = 0.0f;
-	float g = 0.0f;
-	float b = 0.0f;
+	public:
+		float r = 0.0f;
+		float g = 0.0f;
+		float b = 0.0f;
 };
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Thought it was confusing to not have the members of the example struct class have the public keyword. Does not compile otherwise because the rtti struct definition in the .cpp file needs access to it I think, so I edited the example.